### PR TITLE
Fix temporal correlation crash for methods without year in name

### DIFF
--- a/flowsa/flowby.py
+++ b/flowsa/flowby.py
@@ -1432,7 +1432,22 @@ class _FlowBy(pd.DataFrame):
 
         fbs = self.copy()
         if not target_year:
-            target_year = int((re.search(r"\d{4}", fbs.full_name)).group())
+            # Prefer a 4-digit year in the method name (e.g. Employment_national_2023).
+            # Fall back to config year for methods without a year in the name
+            # (e.g. NIPA_FD_common, Detail_Make).
+            name_year = re.search(r"\d{4}", fbs.full_name or '')
+            if name_year:
+                target_year = int(name_year.group())
+            else:
+                target_year = fbs.config.get('year') if fbs.config else None
+            if not target_year:
+                raise ValueError(
+                    f'Unable to determine target year for temporal '
+                    f'correlation of {fbs.full_name}. Include a 4-digit '
+                    f'year in the method name or set "year" in the method '
+                    f'config.'
+                )
+            target_year = int(target_year)
         if 'TemporalCorrelation' not in fbs:
             fbs['TemporalCorrelation'] = 1
         fbs = esupy.dqi.adjust_dqi_scores(fbs, abs(fbs['Year'] - target_year),

--- a/tests/test_temporal_correlation.py
+++ b/tests/test_temporal_correlation.py
@@ -1,0 +1,67 @@
+"""
+Unit tests for assign_temporal_correlation year resolution.
+"""
+import pandas as pd
+import pytest
+from flowsa.flowbysector import FlowBySector
+
+
+def _minimal_fbs(full_name, config, year=2015):
+    """Build a minimal FlowBySector for temporal correlation tests."""
+    df = pd.DataFrame({
+        'Flowable': ['test'],
+        'Class': ['Money'],
+        'SectorProducedBy': ['111'],
+        'SectorConsumedBy': [None],
+        'SectorSourceName': ['NAICS_2017_Code'],
+        'Context': ['emission/air'],
+        'Location': ['00000'],
+        'LocationSystem': ['FIPS_2015'],
+        'FlowAmount': [1.0],
+        'Unit': ['USD'],
+        'FlowType': ['ELEMENTARY_FLOW'],
+        'Year': [year],
+        'MeasureofSpread': [None],
+        'Spread': [None],
+        'DistributionType': [None],
+        'Min': [None],
+        'Max': [None],
+        'DataReliability': [1.0],
+        'TemporalCorrelation': [1.0],
+        'GeographicalCorrelation': [1.0],
+        'TechnologicalCorrelation': [1.0],
+        'DataCollection': [1.0],
+        'MetaSources': ['test'],
+        'FlowUUID': [None],
+    })
+    return FlowBySector(
+        df,
+        full_name=full_name,
+        config=config,
+        convert_df_to_flowby=True,
+    )
+
+
+def test_temporal_correlation_uses_year_from_method_name():
+    fbs = _minimal_fbs('Employment_national_2023', {'year': 2019}, year=2020)
+    result = fbs.assign_temporal_correlation()
+    assert (result['Year'] == 2023).all()
+
+
+def test_temporal_correlation_falls_back_to_config_year():
+    """Methods like NIPA_FD_common have no year in the name."""
+    fbs = _minimal_fbs('NIPA_FD_common', {'year': 2017}, year=2015)
+    result = fbs.assign_temporal_correlation()
+    assert (result['Year'] == 2017).all()
+
+
+def test_temporal_correlation_explicit_target_year():
+    fbs = _minimal_fbs('NIPA_FD_common', {}, year=2015)
+    result = fbs.assign_temporal_correlation(target_year=2018)
+    assert (result['Year'] == 2018).all()
+
+
+def test_temporal_correlation_missing_year_raises():
+    fbs = _minimal_fbs('NIPA_FD_common', {}, year=2015)
+    with pytest.raises(ValueError, match='Unable to determine target year'):
+        fbs.assign_temporal_correlation()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
`NIPA_FD_common` (and similar methods like `Detail_Make`) fail in `assign_temporal_correlation()` with:

```
AttributeError: 'NoneType' object has no attribute 'group'
```

This is **not an environment issue**. The method name has no 4-digit year, and the code only looked for a year in `full_name`.

## Fix
`assign_temporal_correlation()` now:
1. Uses a 4-digit year from the method name when present (existing behavior for methods like `Employment_national_2023`)
2. Falls back to `config['year']` when the name has no year (needed for `NIPA_FD_common`)
3. Raises a clear `ValueError` if neither source provides a year

## Test plan
- [x] Unit tests in `tests/test_temporal_correlation.py` covering name year, config fallback, explicit `target_year`, and missing-year error
- [ ] Re-run `generateFlowBySector('NIPA_FD_common')` on the nipa branch / with the NIPA method YAML present

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a373ac5-503b-41b7-b0f9-30dc64a076d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a373ac5-503b-41b7-b0f9-30dc64a076d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

